### PR TITLE
Add the template map type

### DIFF
--- a/src/main/java/supercoder79/creativeparty/CreativePartyActive.java
+++ b/src/main/java/supercoder79/creativeparty/CreativePartyActive.java
@@ -73,6 +73,6 @@ public class CreativePartyActive {
 		player.setGameMode(GameMode.CREATIVE);
 
 		ServerWorld world = this.gameSpace.getWorld();
-		player.teleport(world, 0, 62, 0, 0.0F, 0.0F);
+		player.teleport(world, 0, this.config.map.mapType.getSpawnY(), 0, 0.0F, 0.0F);
 	}
 }

--- a/src/main/java/supercoder79/creativeparty/CreativePartyWaiting.java
+++ b/src/main/java/supercoder79/creativeparty/CreativePartyWaiting.java
@@ -93,6 +93,6 @@ public class CreativePartyWaiting {
 		player.setGameMode(GameMode.SPECTATOR);
 
 		ServerWorld world = this.gameSpace.getWorld();
-		player.teleport(world, 0, 62, 0, 0.0F, 0.0F);
+		player.teleport(world, 0, this.config.map.mapType.getSpawnY(), 0, 0.0F, 0.0F);
 	}
 }

--- a/src/main/java/supercoder79/creativeparty/map/type/MapType.java
+++ b/src/main/java/supercoder79/creativeparty/map/type/MapType.java
@@ -4,10 +4,14 @@ import java.util.function.Function;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
+
+import xyz.nucleoid.plasmid.game.world.view.VoidBlockView;
 import xyz.nucleoid.plasmid.registry.TinyRegistry;
 
 import net.minecraft.util.Identifier;
+import net.minecraft.world.BlockView;
 import net.minecraft.world.ChunkRegion;
+import net.minecraft.world.Heightmap;
 import net.minecraft.world.chunk.Chunk;
 
 public interface MapType {
@@ -17,6 +21,22 @@ public interface MapType {
 	void populateNoise(ChunkRegion world, Chunk chunk);
 
 	void buildSurface(ChunkRegion world, Chunk chunk);
+
+	default void populateEntities(ChunkRegion world) {
+		return;
+	}
+
+	default int getHeight(int x, int z, Heightmap.Type heightmapType) {
+		return 0;
+	}
+
+	default BlockView getColumnSample(int x, int z) {
+		return VoidBlockView.INSTANCE;
+	}
+
+	default double getSpawnY() {
+		return 62;
+	}
 
 	Identifier biomeId();
 

--- a/src/main/java/supercoder79/creativeparty/map/type/MapTypes.java
+++ b/src/main/java/supercoder79/creativeparty/map/type/MapTypes.java
@@ -8,6 +8,7 @@ public class MapTypes {
 	public static void init() {
 		register("default", DefaultMapType.CODEC);
 		register("layered", LayeredMapType.CODEC);
+		register("template", TemplateMapType.CODEC);
 	}
 
 	private static void register(String identifier, Codec<? extends MapType> type) {

--- a/src/main/java/supercoder79/creativeparty/map/type/TemplateMapType.java
+++ b/src/main/java/supercoder79/creativeparty/map/type/TemplateMapType.java
@@ -1,0 +1,93 @@
+package supercoder79.creativeparty.map.type;
+
+import java.io.IOException;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.ChunkRegion;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.chunk.Chunk;
+import xyz.nucleoid.plasmid.game.GameOpenException;
+import xyz.nucleoid.plasmid.game.world.view.VoidBlockView;
+import xyz.nucleoid.plasmid.map.template.MapTemplate;
+import xyz.nucleoid.plasmid.map.template.MapTemplateSerializer;
+import xyz.nucleoid.plasmid.map.template.TemplateChunkGenerator;
+
+public class TemplateMapType implements MapType {
+	public static final Codec<TemplateMapType> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+			Identifier.CODEC.fieldOf("map_template").forGetter(config -> config.mapTemplateId)
+	).apply(instance, TemplateMapType::new));
+
+	private final Identifier mapTemplateId;
+	private MapTemplate mapTemplate;
+	private TemplateChunkGenerator chunkGenerator;
+
+	public TemplateMapType(Identifier mapTemplateId) {
+		this.mapTemplateId = mapTemplateId;
+	}
+
+	private void ensureMapTemplate() {
+		if (this.mapTemplate == null) {
+			try {
+				this.mapTemplate = MapTemplateSerializer.INSTANCE.loadFromResource(this.mapTemplateId);
+			} catch (IOException e) {
+				throw new GameOpenException(new LiteralText("Failed to load map template"), e);
+			}
+		}
+	}
+
+	private void ensureChunkGenerator(ChunkRegion world) {
+		if (this.chunkGenerator == null) {
+			this.ensureMapTemplate();
+			this.chunkGenerator = new TemplateChunkGenerator(world.toServerWorld().getServer(), this.mapTemplate);
+		}
+	}
+
+	@Override
+	public void populateNoise(ChunkRegion world, Chunk chunk) {
+		this.ensureChunkGenerator(world);
+		this.chunkGenerator.populateNoise(world, world.toServerWorld().getStructureAccessor(), chunk);
+	}
+
+	@Override
+	public void populateEntities(ChunkRegion world) {
+		this.ensureChunkGenerator(world);
+		this.chunkGenerator.populateEntities(world);
+	}
+
+	@Override
+	public int getHeight(int x, int z, Heightmap.Type heightmapType) {
+		return this.chunkGenerator == null ? 0 : this.chunkGenerator.getHeight(x, z, heightmapType);
+	}
+
+	@Override
+	public BlockView getColumnSample(int x, int z) {
+		return this.chunkGenerator == null ? VoidBlockView.INSTANCE : this.chunkGenerator.getColumnSample(x, z);
+	}
+	
+	@Override
+	public double getSpawnY() {
+		this.ensureMapTemplate();
+		return this.mapTemplate.getBounds().getMax().getY();
+	}
+
+	@Override
+	public void buildSurface(ChunkRegion world, Chunk chunk) {
+		return;
+	}
+
+	@Override
+	public Identifier biomeId() {
+		this.ensureMapTemplate();
+		return this.mapTemplate.getBiome().getValue();
+	}
+
+	@Override
+	public Codec<? extends MapType> getCodec() {
+		return CODEC;
+	}
+}


### PR DESCRIPTION
This pull request adds the template map type, which simply generates a map template:

```json
{
	"type": "creative_party:template",
	"map_template": "creativeparty:custom_map_template"
}
```